### PR TITLE
Python 3.5 is EOL at end of the month

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,7 +25,7 @@ MAJORS = {
     "3.2": Status(eol=True),
     "3.3": Status(eol=True),
     "3.4": Status(eol=True),
-    "3.5": Status(eol=True),
+    "3.5": Status(dying=True),
     "3.6": Status(),
     "3.7": Status(),
     "3.8": Status(),


### PR DESCRIPTION
Reverts #4.

Re: https://github.com/di/pyreadiness/pull/4#issuecomment-691875303