### PR TITLE
Remove whitespace and apostrophe

### DIFF
--- a/templates/major.html
+++ b/templates/major.html
@@ -9,12 +9,12 @@
     <p>
     Python {{ major }} is <a href="https://devguide.python.org/devcycle/#end-of-life-branches">
         {% if status.eol %}
-            a version of Python that is past it's End Of Life
+            a version of Python that is past its End Of Life
         {% elif status.dying %}
-            a version of Python that is nearing it's End Of Life
+            a version of Python that is nearing its End Of Life
         {% else %}
             a currently supported version of Python
-        {% endif %}
+        {% endif -%}
     </a>. This site shows Python {{ major }} support for the {{ results|length }} most downloaded packages on <a href="https://pypi.org/">PyPI</a>:
     </p>
     <ol>


### PR DESCRIPTION
Remove unneeded whitespace before the fullstop and an apostrophe.

Note: I've not tested the template whitespace stripping.

![image](https://user-images.githubusercontent.com/1324225/116518788-5f967e80-a8d9-11eb-9d6e-99e3f1fdfc21.png)

https://pyreadiness.org/3.5/

![image](https://user-images.githubusercontent.com/1324225/116518681-3d9cfc00-a8d9-11eb-98d7-d1e7873bf2bc.png)
