### PR TITLE
Add back `toggle` JavaScript function

### DIFF
--- a/templates/major.html
+++ b/templates/major.html
@@ -1,6 +1,36 @@
 {% extends "base.html" %}
 {% block title %}Python {{ major }} Readiness - Python {{ major }} support table for most popular Python packages{% endblock %}
 {% block content %}
+<script type="text/javascript">
+  function toggle(button) {
+    var nextState = button.dataset.state === "Show" ? "Hide" : "Show";
+
+    if (button.dataset.state === "Show") {
+      document.querySelectorAll(".btn-success").forEach((el) => {
+        el.classList.remove("hidden");
+      });
+    } else {
+      document.querySelectorAll(".btn-success").forEach((el) => {
+        el.classList.add("hidden");
+      });
+    }
+
+    button.dataset.state = nextState;
+    button.textContent = nextState + ' Python {{ major }} {{ "unsupported" if status.eol else "compatible"}}';
+
+    document.querySelectorAll(".list").forEach((list) => {
+      var items = list.querySelectorAll(":not(.hidden)");
+
+      if (items.length) {
+        items.forEach((el) => {
+          el.classList.remove("btn-first-child", "btn-last-child");
+        });
+        items[0].classList.add("btn-first-child");
+        items[items.length-1].classList.add("btn-last-child");
+      }
+    });
+  }
+</script>
 <div class="row">
   <div class="col-sm-12 col-md-12">
     <h1>Python {{ major }} Readiness</h1>

--- a/templates/major.html
+++ b/templates/major.html
@@ -1,6 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Python {{ major }} Readiness - Python {{ major }} support table for most popular Python packages{% endblock %}
-{% block content %}
+{% block head %}
 <script type="text/javascript">
   function toggle(button) {
     var nextState = button.dataset.state === "Show" ? "Hide" : "Show";
@@ -31,6 +30,9 @@
     });
   }
 </script>
+{% endblock %}
+{% block title %}Python {{ major }} Readiness - Python {{ major }} support table for most popular Python packages{% endblock %}
+{% block content %}
 <div class="row">
   <div class="col-sm-12 col-md-12">
     <h1>Python {{ major }} Readiness</h1>


### PR DESCRIPTION
The toggle to show/hide compatible/unsupported packages in major pages is broken:

<img width="1074" alt="Screenshot 2021-10-02 at 00 13 28" src="https://user-images.githubusercontent.com/5970971/135691663-fcb5d3fb-4dd9-474a-a297-875903bec6ee.png">


Seems like the `toggle` JavaScript function was lost during a refactoring in https://github.com/di/pyreadiness/commit/a6adbdd28fb2ffec01c19b55acff98e564a79b3d

*Note: Just in case, I made a draft pull request to showcase the final result [here](https://github.com/mkniewallner/pyreadiness/pull/1) by hardcoding a list of packages (as I don't have access to Google credentials).*