### PR TITLE
Pin deploy to Python 3.9

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -12,6 +12,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Set up Python
         uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
       - name: Generate
         run: |
           printenv SERVICE_ACCOUNT_JSON > "$GOOGLE_APPLICATION_CREDENTIALS"


### PR DESCRIPTION
Fixes #21.

The problem is that https://github.com/actions/setup-python has switched the default Python from 3.9 to 3.10:

* Last pass: https://github.com/di/pyreadiness/runs/3958633265?check_suite_focus=true#step:3:8
* First fail: https://github.com/di/pyreadiness/runs/3970848867?check_suite_focus=true#step:3:8

And one of the dependencies (https://pypi.org/project/google-cloud-storage/) doesn't yet support Python 3.10.
