### PR TITLE
Upgrade Jinja2 to fix incompatibility with newer markupsafe

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 google-cloud-bigquery==1.7.0
 google-cloud-storage==1.13.0
-jinja2==2.11.3
+jinja2==3.0.3


### PR DESCRIPTION
Cron deploys have broken:

```
Collecting google-cloud-bigquery==1.7.0
  Downloading google_cloud_bigquery-1.7.0-py2.py3-none-any.whl (84 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 84.6/84.6 KB 15.9 MB/s eta 0:00:00
Collecting google-cloud-storage==1.13.0
  Downloading google_cloud_storage-1.13.0-py2.py3-none-any.whl (59 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 59.4/59.4 KB 14.6 MB/s eta 0:00:00
Collecting jinja2==2.11.3
  Downloading Jinja2-2.11.3-py2.py3-none-any.whl (125 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 125.7/125.7 KB 23.0 MB/s eta 0:00:00
Collecting google-api-core<2.0.0dev,>=1.0.0
  Downloading google_api_core-1.31.5-py2.py3-none-any.whl (93 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 93.3/93.3 KB 24.1 MB/s eta 0:00:00
Collecting google-cloud-core<0.29dev,>=0.28.0
  Downloading google_cloud_core-0.28.1-py2.py3-none-any.whl (25 kB)
Collecting google-resumable-media>=0.2.1
  Downloading google_resumable_media-2.3.2-py2.py3-none-any.whl (76 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 76.8/76.8 KB 19.4 MB/s eta 0:00:00
Collecting MarkupSafe>=0.23
  Downloading MarkupSafe-2.1.1-cp39-cp39-manylinux_2_[17](https://github.com/di/pyreadiness/runs/5653172092?check_suite_focus=true#step:4:17)_x86_64.manylinux2014_x86_64.whl (25 kB)
Collecting packaging>=14.3
  Downloading packaging-21.3-py3-none-any.whl (40 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 40.8/40.8 KB 4.1 MB/s eta 0:00:00
Collecting six>=1.13.0
  Downloading six-1.16.0-py2.py3-none-any.whl (11 kB)
Collecting googleapis-common-protos<2.0dev,>=1.6.0
  Downloading googleapis_common_protos-1.56.0-py2.py3-none-any.whl (241 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 241.5/241.5 KB 49.1 MB/s eta 0:00:00
Collecting protobuf>=3.12.0
  Downloading protobuf-3.19.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (1.1 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.1/1.1 MB 42.2 MB/s eta 0:00:00
Requirement already satisfied: setuptools>=40.3.0 in /opt/hostedtoolcache/Python/3.9.10/x64/lib/python3.9/site-packages (from google-api-core<2.0.0dev,>=1.0.0->google-cloud-bigquery==1.7.0->-r requirements.txt (line 1)) (58.1.0)
Collecting requests<3.0.0dev,>=2.[18](https://github.com/di/pyreadiness/runs/5653172092?check_suite_focus=true#step:4:18).0
  Downloading requests-2.27.1-py2.py3-none-any.whl (63 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 63.1/63.1 KB 13.7 MB/s eta 0:00:00
Collecting google-auth<2.0dev,>=1.25.0
  Downloading google_auth-1.35.0-py2.py3-none-any.whl (152 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 152.9/152.9 KB 28.8 MB/s eta 0:00:00
Collecting pytz
  Downloading pytz-2022.1-py2.py3-none-any.whl (503 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 503.5/503.5 KB 56.3 MB/s eta 0:00:00
Collecting google-crc32c<2.0dev,>=1.0
  Downloading google_crc32c-1.3.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl (36 kB)
Collecting cachetools<5.0,>=2.0.0
  Downloading cachetools-4.2.4-py3-none-any.whl (10 kB)
Collecting rsa<5,>=3.1.4
  Downloading rsa-4.8-py3-none-any.whl (39 kB)
Collecting pyasn1-modules>=0.2.1
  Downloading pyasn1_modules-0.2.8-py2.py3-none-any.whl (155 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 155.3/155.3 KB 34.9 MB/s eta 0:00:00
Collecting pyparsing!=3.0.5,>=2.0.2
  Downloading pyparsing-3.0.7-py3-none-any.whl (98 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 98.0/98.0 KB 24.7 MB/s eta 0:00:00
Collecting idna<4,>=2.5
  Downloading idna-3.3-py3-none-any.whl (61 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 61.2/61.2 KB 12.9 MB/s eta 0:00:00
Collecting urllib3<1.27,>=1.21.1
  Downloading urllib3-1.26.9-py2.py3-none-any.whl (138 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 139.0/139.0 KB 28.0 MB/s eta 0:00:00
Collecting charset-normalizer~=2.0.0
  Downloading charset_normalizer-2.0.12-py3-none-any.whl (39 kB)
Collecting certifi>=2017.4.17
  Downloading certifi-2021.10.8-py2.py3-none-any.whl (149 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 149.2/149.2 KB 37.3 MB/s eta 0:00:00
Collecting pyasn1<0.5.0,>=0.4.6
  Downloading pyasn1-0.4.8-py2.py3-none-any.whl (77 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 77.1/77.1 KB [19](https://github.com/di/pyreadiness/runs/5653172092?check_suite_focus=true#step:4:19).4 MB/s eta 0:00:00
Installing collected packages: pytz, pyasn1, certifi, urllib3, six, rsa, pyparsing, pyasn1-modules, protobuf, MarkupSafe, idna, google-crc32c, charset-normalizer, cachetools, requests, packaging, jinja2, googleapis-common-protos, google-resumable-media, google-auth, google-api-core, google-cloud-core, google-cloud-storage, google-cloud-bigquery
Successfully installed MarkupSafe-2.1.1 cachetools-4.2.4 certifi-[20](https://github.com/di/pyreadiness/runs/5653172092?check_suite_focus=true#step:4:20)[21](https://github.com/di/pyreadiness/runs/5653172092?check_suite_focus=true#step:4:21).10.8 charset-normalizer-2.0.12 google-api-core-1.31.5 google-auth-1.35.0 google-cloud-bigquery-1.7.0 google-cloud-core-0.28.1 google-cloud-storage-1.13.0 google-crc32c-1.3.0 google-resumable-media-2.3.2 googleapis-common-protos-1.56.0 idna-3.3 jinja2-2.11.3 packaging-21.3 protobuf-3.19.4 pyasn1-0.4.8 pyasn1-modules-0.2.8 pyparsing-3.0.7 pytz-20[22](https://github.com/di/pyreadiness/runs/5653172092?check_suite_focus=true#step:4:22).1 requests-2.27.1 rsa-4.8 six-1.16.0 urllib3-1.26.9
WARNING: You are using pip version 22.0.3; however, version 22.0.4 is available.
You should consider upgrading via the '/opt/hostedtoolcache/Python/3.9.10/x64/bin/python -m pip install --upgrade pip' command.
Traceback (most recent call last):
  File "/home/runner/work/pyreadiness/pyreadiness/main.py", line 10, in <module>
    import jinja2
  File "/opt/hostedtoolcache/Python/3.9.10/x64/lib/python3.9/site-packages/jinja2/__init__.py", line 12, in <module>
    from .environment import Environment
  File "/opt/hostedtoolcache/Python/3.9.10/x64/lib/python3.9/site-packages/jinja2/environment.py", line [25](https://github.com/di/pyreadiness/runs/5653172092?check_suite_focus=true#step:4:25), in <module>
    from .defaults import BLOCK_END_STRING
  File "/opt/hostedtoolcache/Python/3.9.10/x64/lib/python3.9/site-packages/jinja2/defaults.py", line 3, in <module>
    from .filters import FILTERS as DEFAULT_FILTERS  # noqa: F[40](https://github.com/di/pyreadiness/runs/5653172092?check_suite_focus=true#step:4:40)1
  File "/opt/hostedtoolcache/Python/3.9.10/x[64](https://github.com/di/pyreadiness/runs/5653172092?check_suite_focus=true#step:4:64)/lib/python3.9/site-packages/jinja2/filters.py", line 13, in <module>
    from markupsafe import soft_unicode
ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/opt/hostedtoolcache/Python/3.9.10/x64/lib/python3.9/site-packages/markupsafe/__init__.py)
Error: Process completed with exit code 1.
```

https://github.com/di/pyreadiness/runs/5653172092?check_suite_focus=true

Looks like the old Jinja2 isn't compatible with a newer markupsafe. The newer Jinja2 should be fine.

* https://github.com/pallets/jinja/issues/1585
* https://github.com/pallets/jinja/releases/tag/3.0.0