### PR TITLE
Add workflow_dispatch to add a button to manually trigger builds

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -10,11 +10,12 @@ jobs:
       SERVICE_ACCOUNT_JSON: ${{ secrets.SERVICE_ACCOUNT_JSON}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
-          python-version: "3.9"
+          python-version: "3.10"
+          cache: pip
       - name: Generate
         run: |
           printenv SERVICE_ACCOUNT_JSON > "$GOOGLE_APPLICATION_CREDENTIALS"

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,6 +1,7 @@
 on:
    schedule:
    - cron: '0 0 * * *'
+   workflow_dispatch:
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
`workflow_dispatch` is the config needed to add a button to manually trigger a build, so we don't need to wait for the cron to check things like https://github.com/di/pyreadiness/pull/25 actually worked.

https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/

Also bump some versions and cache pip.