### PR TITLE
Update google-cloud-* for Python 3.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-google-cloud-bigquery==1.7.0
-google-cloud-storage==1.13.0
+google-cloud-bigquery==2.34.2
+google-cloud-storage==2.2.1
 jinja2==3.0.3


### PR DESCRIPTION
Both declare support for 3.10:

https://pypi.org/project/google-cloud-bigquery/
https://pypi.org/project/google-cloud-storage/
