### PR TITLE
update links in documentation and templates

### DIFF
--- a/docs/2.3/index.html
+++ b/docs/2.3/index.html
@@ -1618,12 +1618,12 @@
 </div>
 
     <h2>Thanks</h2>
-    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="http://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
+    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
     <!-- fork me -->
     <a href="https://github.com/di/pyreadiness"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github-camo.global.ssl.fastly.net/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
     <hr>
     <footer>
-      <p>Maintained by <a href="http://github.com/di">@di</a>, source on <a href="https://github.com/di/pyreadiness">GitHub</a>.</p>
+      <p>Maintained by <a href="https://github.com/di">@di</a>, source on <a href="https://github.com/di/pyreadiness">GitHub</a>.</p>
       <p>Last updated on <span class="date">2022-11-08 00:25:01.111178</span></p>
     </footer>
   </div>

--- a/docs/2.3/index.html
+++ b/docs/2.3/index.html
@@ -1618,7 +1618,7 @@
 </div>
 
     <h2>Thanks</h2>
-    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
+    <p>This is derivative work from py3readiness.org, a site that previously tracked general compatibility with Python 3, which in turn was a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
     <!-- fork me -->
     <a href="https://github.com/di/pyreadiness"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github-camo.global.ssl.fastly.net/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
     <hr>

--- a/docs/2.4/index.html
+++ b/docs/2.4/index.html
@@ -1618,12 +1618,12 @@
 </div>
 
     <h2>Thanks</h2>
-    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="http://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
+    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
     <!-- fork me -->
     <a href="https://github.com/di/pyreadiness"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github-camo.global.ssl.fastly.net/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
     <hr>
     <footer>
-      <p>Maintained by <a href="http://github.com/di">@di</a>, source on <a href="https://github.com/di/pyreadiness">GitHub</a>.</p>
+      <p>Maintained by <a href="https://github.com/di">@di</a>, source on <a href="https://github.com/di/pyreadiness">GitHub</a>.</p>
       <p>Last updated on <span class="date">2022-11-08 00:25:01.111178</span></p>
     </footer>
   </div>

--- a/docs/2.4/index.html
+++ b/docs/2.4/index.html
@@ -1618,7 +1618,7 @@
 </div>
 
     <h2>Thanks</h2>
-    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
+    <p>This is derivative work from py3readiness.org, a site that previously tracked general compatibility with Python 3, which in turn was a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
     <!-- fork me -->
     <a href="https://github.com/di/pyreadiness"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github-camo.global.ssl.fastly.net/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
     <hr>

--- a/docs/2.5/index.html
+++ b/docs/2.5/index.html
@@ -1618,12 +1618,12 @@
 </div>
 
     <h2>Thanks</h2>
-    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="http://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
+    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
     <!-- fork me -->
     <a href="https://github.com/di/pyreadiness"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github-camo.global.ssl.fastly.net/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
     <hr>
     <footer>
-      <p>Maintained by <a href="http://github.com/di">@di</a>, source on <a href="https://github.com/di/pyreadiness">GitHub</a>.</p>
+      <p>Maintained by <a href="https://github.com/di">@di</a>, source on <a href="https://github.com/di/pyreadiness">GitHub</a>.</p>
       <p>Last updated on <span class="date">2022-11-08 00:25:01.111178</span></p>
     </footer>
   </div>

--- a/docs/2.5/index.html
+++ b/docs/2.5/index.html
@@ -1618,7 +1618,7 @@
 </div>
 
     <h2>Thanks</h2>
-    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
+    <p>This is derivative work from py3readiness.org, a site that previously tracked general compatibility with Python 3, which in turn was a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
     <!-- fork me -->
     <a href="https://github.com/di/pyreadiness"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github-camo.global.ssl.fastly.net/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
     <hr>

--- a/docs/2.6/index.html
+++ b/docs/2.6/index.html
@@ -1618,12 +1618,12 @@
 </div>
 
     <h2>Thanks</h2>
-    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="http://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
+    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
     <!-- fork me -->
     <a href="https://github.com/di/pyreadiness"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github-camo.global.ssl.fastly.net/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
     <hr>
     <footer>
-      <p>Maintained by <a href="http://github.com/di">@di</a>, source on <a href="https://github.com/di/pyreadiness">GitHub</a>.</p>
+      <p>Maintained by <a href="https://github.com/di">@di</a>, source on <a href="https://github.com/di/pyreadiness">GitHub</a>.</p>
       <p>Last updated on <span class="date">2022-11-08 00:25:01.111178</span></p>
     </footer>
   </div>

--- a/docs/2.6/index.html
+++ b/docs/2.6/index.html
@@ -1618,7 +1618,7 @@
 </div>
 
     <h2>Thanks</h2>
-    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
+    <p>This is derivative work from py3readiness.org, a site that previously tracked general compatibility with Python 3, which in turn was a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
     <!-- fork me -->
     <a href="https://github.com/di/pyreadiness"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github-camo.global.ssl.fastly.net/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
     <hr>

--- a/docs/2.7/index.html
+++ b/docs/2.7/index.html
@@ -1618,12 +1618,12 @@
 </div>
 
     <h2>Thanks</h2>
-    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="http://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
+    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
     <!-- fork me -->
     <a href="https://github.com/di/pyreadiness"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github-camo.global.ssl.fastly.net/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
     <hr>
     <footer>
-      <p>Maintained by <a href="http://github.com/di">@di</a>, source on <a href="https://github.com/di/pyreadiness">GitHub</a>.</p>
+      <p>Maintained by <a href="https://github.com/di">@di</a>, source on <a href="https://github.com/di/pyreadiness">GitHub</a>.</p>
       <p>Last updated on <span class="date">2022-11-08 00:25:01.111178</span></p>
     </footer>
   </div>

--- a/docs/2.7/index.html
+++ b/docs/2.7/index.html
@@ -1618,7 +1618,7 @@
 </div>
 
     <h2>Thanks</h2>
-    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
+    <p>This is derivative work from py3readiness.org, a site that previously tracked general compatibility with Python 3, which in turn was a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
     <!-- fork me -->
     <a href="https://github.com/di/pyreadiness"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github-camo.global.ssl.fastly.net/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
     <hr>

--- a/docs/3.0/index.html
+++ b/docs/3.0/index.html
@@ -1618,12 +1618,12 @@
 </div>
 
     <h2>Thanks</h2>
-    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="http://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
+    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
     <!-- fork me -->
     <a href="https://github.com/di/pyreadiness"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github-camo.global.ssl.fastly.net/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
     <hr>
     <footer>
-      <p>Maintained by <a href="http://github.com/di">@di</a>, source on <a href="https://github.com/di/pyreadiness">GitHub</a>.</p>
+      <p>Maintained by <a href="https://github.com/di">@di</a>, source on <a href="https://github.com/di/pyreadiness">GitHub</a>.</p>
       <p>Last updated on <span class="date">2022-11-08 00:25:01.111178</span></p>
     </footer>
   </div>

--- a/docs/3.0/index.html
+++ b/docs/3.0/index.html
@@ -1618,7 +1618,7 @@
 </div>
 
     <h2>Thanks</h2>
-    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
+    <p>This is derivative work from py3readiness.org, a site that previously tracked general compatibility with Python 3, which in turn was a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
     <!-- fork me -->
     <a href="https://github.com/di/pyreadiness"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github-camo.global.ssl.fastly.net/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
     <hr>

--- a/docs/3.1/index.html
+++ b/docs/3.1/index.html
@@ -1618,12 +1618,12 @@
 </div>
 
     <h2>Thanks</h2>
-    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="http://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
+    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
     <!-- fork me -->
     <a href="https://github.com/di/pyreadiness"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github-camo.global.ssl.fastly.net/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
     <hr>
     <footer>
-      <p>Maintained by <a href="http://github.com/di">@di</a>, source on <a href="https://github.com/di/pyreadiness">GitHub</a>.</p>
+      <p>Maintained by <a href="https://github.com/di">@di</a>, source on <a href="https://github.com/di/pyreadiness">GitHub</a>.</p>
       <p>Last updated on <span class="date">2022-11-08 00:25:01.111178</span></p>
     </footer>
   </div>

--- a/docs/3.1/index.html
+++ b/docs/3.1/index.html
@@ -1618,7 +1618,7 @@
 </div>
 
     <h2>Thanks</h2>
-    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
+    <p>This is derivative work from py3readiness.org, a site that previously tracked general compatibility with Python 3, which in turn was a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
     <!-- fork me -->
     <a href="https://github.com/di/pyreadiness"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github-camo.global.ssl.fastly.net/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
     <hr>

--- a/docs/3.10/index.html
+++ b/docs/3.10/index.html
@@ -1618,12 +1618,12 @@
 </div>
 
     <h2>Thanks</h2>
-    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="http://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
+    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
     <!-- fork me -->
     <a href="https://github.com/di/pyreadiness"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github-camo.global.ssl.fastly.net/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
     <hr>
     <footer>
-      <p>Maintained by <a href="http://github.com/di">@di</a>, source on <a href="https://github.com/di/pyreadiness">GitHub</a>.</p>
+      <p>Maintained by <a href="https://github.com/di">@di</a>, source on <a href="https://github.com/di/pyreadiness">GitHub</a>.</p>
       <p>Last updated on <span class="date">2022-11-08 00:25:01.111178</span></p>
     </footer>
   </div>

--- a/docs/3.10/index.html
+++ b/docs/3.10/index.html
@@ -1618,7 +1618,7 @@
 </div>
 
     <h2>Thanks</h2>
-    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
+    <p>This is derivative work from py3readiness.org, a site that previously tracked general compatibility with Python 3, which in turn was a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
     <!-- fork me -->
     <a href="https://github.com/di/pyreadiness"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github-camo.global.ssl.fastly.net/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
     <hr>

--- a/docs/3.11/index.html
+++ b/docs/3.11/index.html
@@ -1618,12 +1618,12 @@
 </div>
 
     <h2>Thanks</h2>
-    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="http://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
+    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
     <!-- fork me -->
     <a href="https://github.com/di/pyreadiness"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github-camo.global.ssl.fastly.net/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
     <hr>
     <footer>
-      <p>Maintained by <a href="http://github.com/di">@di</a>, source on <a href="https://github.com/di/pyreadiness">GitHub</a>.</p>
+      <p>Maintained by <a href="https://github.com/di">@di</a>, source on <a href="https://github.com/di/pyreadiness">GitHub</a>.</p>
       <p>Last updated on <span class="date">2022-11-08 00:25:01.111178</span></p>
     </footer>
   </div>

--- a/docs/3.11/index.html
+++ b/docs/3.11/index.html
@@ -1618,7 +1618,7 @@
 </div>
 
     <h2>Thanks</h2>
-    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
+    <p>This is derivative work from py3readiness.org, a site that previously tracked general compatibility with Python 3, which in turn was a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
     <!-- fork me -->
     <a href="https://github.com/di/pyreadiness"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github-camo.global.ssl.fastly.net/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
     <hr>

--- a/docs/3.12/index.html
+++ b/docs/3.12/index.html
@@ -1618,12 +1618,12 @@
 </div>
 
     <h2>Thanks</h2>
-    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="http://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
+    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
     <!-- fork me -->
     <a href="https://github.com/di/pyreadiness"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github-camo.global.ssl.fastly.net/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
     <hr>
     <footer>
-      <p>Maintained by <a href="http://github.com/di">@di</a>, source on <a href="https://github.com/di/pyreadiness">GitHub</a>.</p>
+      <p>Maintained by <a href="https://github.com/di">@di</a>, source on <a href="https://github.com/di/pyreadiness">GitHub</a>.</p>
       <p>Last updated on <span class="date">2022-11-08 00:25:01.111178</span></p>
     </footer>
   </div>

--- a/docs/3.12/index.html
+++ b/docs/3.12/index.html
@@ -1618,7 +1618,7 @@
 </div>
 
     <h2>Thanks</h2>
-    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
+    <p>This is derivative work from py3readiness.org, a site that previously tracked general compatibility with Python 3, which in turn was a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
     <!-- fork me -->
     <a href="https://github.com/di/pyreadiness"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github-camo.global.ssl.fastly.net/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
     <hr>

--- a/docs/3.2/index.html
+++ b/docs/3.2/index.html
@@ -1618,12 +1618,12 @@
 </div>
 
     <h2>Thanks</h2>
-    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="http://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
+    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
     <!-- fork me -->
     <a href="https://github.com/di/pyreadiness"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github-camo.global.ssl.fastly.net/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
     <hr>
     <footer>
-      <p>Maintained by <a href="http://github.com/di">@di</a>, source on <a href="https://github.com/di/pyreadiness">GitHub</a>.</p>
+      <p>Maintained by <a href="https://github.com/di">@di</a>, source on <a href="https://github.com/di/pyreadiness">GitHub</a>.</p>
       <p>Last updated on <span class="date">2022-11-08 00:25:01.111178</span></p>
     </footer>
   </div>

--- a/docs/3.2/index.html
+++ b/docs/3.2/index.html
@@ -1618,7 +1618,7 @@
 </div>
 
     <h2>Thanks</h2>
-    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
+    <p>This is derivative work from py3readiness.org, a site that previously tracked general compatibility with Python 3, which in turn was a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
     <!-- fork me -->
     <a href="https://github.com/di/pyreadiness"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github-camo.global.ssl.fastly.net/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
     <hr>

--- a/docs/3.3/index.html
+++ b/docs/3.3/index.html
@@ -1618,12 +1618,12 @@
 </div>
 
     <h2>Thanks</h2>
-    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="http://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
+    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
     <!-- fork me -->
     <a href="https://github.com/di/pyreadiness"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github-camo.global.ssl.fastly.net/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
     <hr>
     <footer>
-      <p>Maintained by <a href="http://github.com/di">@di</a>, source on <a href="https://github.com/di/pyreadiness">GitHub</a>.</p>
+      <p>Maintained by <a href="https://github.com/di">@di</a>, source on <a href="https://github.com/di/pyreadiness">GitHub</a>.</p>
       <p>Last updated on <span class="date">2022-11-08 00:25:01.111178</span></p>
     </footer>
   </div>

--- a/docs/3.3/index.html
+++ b/docs/3.3/index.html
@@ -1618,7 +1618,7 @@
 </div>
 
     <h2>Thanks</h2>
-    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
+    <p>This is derivative work from py3readiness.org, a site that previously tracked general compatibility with Python 3, which in turn was a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
     <!-- fork me -->
     <a href="https://github.com/di/pyreadiness"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github-camo.global.ssl.fastly.net/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
     <hr>

--- a/docs/3.4/index.html
+++ b/docs/3.4/index.html
@@ -1618,12 +1618,12 @@
 </div>
 
     <h2>Thanks</h2>
-    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="http://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
+    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
     <!-- fork me -->
     <a href="https://github.com/di/pyreadiness"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github-camo.global.ssl.fastly.net/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
     <hr>
     <footer>
-      <p>Maintained by <a href="http://github.com/di">@di</a>, source on <a href="https://github.com/di/pyreadiness">GitHub</a>.</p>
+      <p>Maintained by <a href="https://github.com/di">@di</a>, source on <a href="https://github.com/di/pyreadiness">GitHub</a>.</p>
       <p>Last updated on <span class="date">2022-11-08 00:25:01.111178</span></p>
     </footer>
   </div>

--- a/docs/3.4/index.html
+++ b/docs/3.4/index.html
@@ -1618,7 +1618,7 @@
 </div>
 
     <h2>Thanks</h2>
-    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
+    <p>This is derivative work from py3readiness.org, a site that previously tracked general compatibility with Python 3, which in turn was a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
     <!-- fork me -->
     <a href="https://github.com/di/pyreadiness"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github-camo.global.ssl.fastly.net/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
     <hr>

--- a/docs/3.5/index.html
+++ b/docs/3.5/index.html
@@ -1618,12 +1618,12 @@
 </div>
 
     <h2>Thanks</h2>
-    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="http://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
+    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
     <!-- fork me -->
     <a href="https://github.com/di/pyreadiness"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github-camo.global.ssl.fastly.net/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
     <hr>
     <footer>
-      <p>Maintained by <a href="http://github.com/di">@di</a>, source on <a href="https://github.com/di/pyreadiness">GitHub</a>.</p>
+      <p>Maintained by <a href="https://github.com/di">@di</a>, source on <a href="https://github.com/di/pyreadiness">GitHub</a>.</p>
       <p>Last updated on <span class="date">2022-11-08 00:25:01.111178</span></p>
     </footer>
   </div>

--- a/docs/3.5/index.html
+++ b/docs/3.5/index.html
@@ -1618,7 +1618,7 @@
 </div>
 
     <h2>Thanks</h2>
-    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
+    <p>This is derivative work from py3readiness.org, a site that previously tracked general compatibility with Python 3, which in turn was a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
     <!-- fork me -->
     <a href="https://github.com/di/pyreadiness"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github-camo.global.ssl.fastly.net/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
     <hr>

--- a/docs/3.6/index.html
+++ b/docs/3.6/index.html
@@ -1618,12 +1618,12 @@
 </div>
 
     <h2>Thanks</h2>
-    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="http://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
+    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
     <!-- fork me -->
     <a href="https://github.com/di/pyreadiness"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github-camo.global.ssl.fastly.net/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
     <hr>
     <footer>
-      <p>Maintained by <a href="http://github.com/di">@di</a>, source on <a href="https://github.com/di/pyreadiness">GitHub</a>.</p>
+      <p>Maintained by <a href="https://github.com/di">@di</a>, source on <a href="https://github.com/di/pyreadiness">GitHub</a>.</p>
       <p>Last updated on <span class="date">2022-11-08 00:25:01.111178</span></p>
     </footer>
   </div>

--- a/docs/3.6/index.html
+++ b/docs/3.6/index.html
@@ -1618,7 +1618,7 @@
 </div>
 
     <h2>Thanks</h2>
-    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
+    <p>This is derivative work from py3readiness.org, a site that previously tracked general compatibility with Python 3, which in turn was a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
     <!-- fork me -->
     <a href="https://github.com/di/pyreadiness"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github-camo.global.ssl.fastly.net/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
     <hr>

--- a/docs/3.7/index.html
+++ b/docs/3.7/index.html
@@ -1618,12 +1618,12 @@
 </div>
 
     <h2>Thanks</h2>
-    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="http://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
+    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
     <!-- fork me -->
     <a href="https://github.com/di/pyreadiness"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github-camo.global.ssl.fastly.net/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
     <hr>
     <footer>
-      <p>Maintained by <a href="http://github.com/di">@di</a>, source on <a href="https://github.com/di/pyreadiness">GitHub</a>.</p>
+      <p>Maintained by <a href="https://github.com/di">@di</a>, source on <a href="https://github.com/di/pyreadiness">GitHub</a>.</p>
       <p>Last updated on <span class="date">2022-11-08 00:25:01.111178</span></p>
     </footer>
   </div>

--- a/docs/3.7/index.html
+++ b/docs/3.7/index.html
@@ -1618,7 +1618,7 @@
 </div>
 
     <h2>Thanks</h2>
-    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
+    <p>This is derivative work from py3readiness.org, a site that previously tracked general compatibility with Python 3, which in turn was a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
     <!-- fork me -->
     <a href="https://github.com/di/pyreadiness"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github-camo.global.ssl.fastly.net/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
     <hr>

--- a/docs/3.8/index.html
+++ b/docs/3.8/index.html
@@ -1618,12 +1618,12 @@
 </div>
 
     <h2>Thanks</h2>
-    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="http://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
+    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
     <!-- fork me -->
     <a href="https://github.com/di/pyreadiness"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github-camo.global.ssl.fastly.net/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
     <hr>
     <footer>
-      <p>Maintained by <a href="http://github.com/di">@di</a>, source on <a href="https://github.com/di/pyreadiness">GitHub</a>.</p>
+      <p>Maintained by <a href="https://github.com/di">@di</a>, source on <a href="https://github.com/di/pyreadiness">GitHub</a>.</p>
       <p>Last updated on <span class="date">2022-11-08 00:25:01.111178</span></p>
     </footer>
   </div>

--- a/docs/3.8/index.html
+++ b/docs/3.8/index.html
@@ -1618,7 +1618,7 @@
 </div>
 
     <h2>Thanks</h2>
-    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
+    <p>This is derivative work from py3readiness.org, a site that previously tracked general compatibility with Python 3, which in turn was a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
     <!-- fork me -->
     <a href="https://github.com/di/pyreadiness"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github-camo.global.ssl.fastly.net/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
     <hr>

--- a/docs/3.9/index.html
+++ b/docs/3.9/index.html
@@ -1618,12 +1618,12 @@
 </div>
 
     <h2>Thanks</h2>
-    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="http://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
+    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
     <!-- fork me -->
     <a href="https://github.com/di/pyreadiness"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github-camo.global.ssl.fastly.net/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
     <hr>
     <footer>
-      <p>Maintained by <a href="http://github.com/di">@di</a>, source on <a href="https://github.com/di/pyreadiness">GitHub</a>.</p>
+      <p>Maintained by <a href="https://github.com/di">@di</a>, source on <a href="https://github.com/di/pyreadiness">GitHub</a>.</p>
       <p>Last updated on <span class="date">2022-11-08 00:25:01.111178</span></p>
     </footer>
   </div>

--- a/docs/3.9/index.html
+++ b/docs/3.9/index.html
@@ -1618,7 +1618,7 @@
 </div>
 
     <h2>Thanks</h2>
-    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
+    <p>This is derivative work from py3readiness.org, a site that previously tracked general compatibility with Python 3, which in turn was a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
     <!-- fork me -->
     <a href="https://github.com/di/pyreadiness"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github-camo.global.ssl.fastly.net/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
     <hr>

--- a/docs/index.html
+++ b/docs/index.html
@@ -283,12 +283,12 @@
 </div>
 
     <h2>Thanks</h2>
-    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="http://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
+    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
     <!-- fork me -->
     <a href="https://github.com/di/pyreadiness"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github-camo.global.ssl.fastly.net/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
     <hr>
     <footer>
-      <p>Maintained by <a href="http://github.com/di">@di</a>, source on <a href="https://github.com/di/pyreadiness">GitHub</a>.</p>
+      <p>Maintained by <a href="https://github.com/di">@di</a>, source on <a href="https://github.com/di/pyreadiness">GitHub</a>.</p>
       <p>Last updated on <span class="date">2022-11-08 00:25:01.111178</span></p>
     </footer>
   </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -283,7 +283,7 @@
 </div>
 
     <h2>Thanks</h2>
-    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
+    <p>This is derivative work from py3readiness.org, a site that previously tracked general compatibility with Python 3, which in turn was a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
     <!-- fork me -->
     <a href="https://github.com/di/pyreadiness"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github-camo.global.ssl.fastly.net/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
     <hr>

--- a/templates/base.html
+++ b/templates/base.html
@@ -53,7 +53,7 @@
   <div class="container">
     {% block content %}{% endblock %}
     <h2>Thanks</h2>
-    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
+    <p>This is derivative work from py3readiness.org, a site that previously tracked general compatibility with Python 3, which in turn was a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
     <!-- fork me -->
     <a href="https://github.com/di/pyreadiness"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github-camo.global.ssl.fastly.net/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
     <hr>

--- a/templates/base.html
+++ b/templates/base.html
@@ -53,12 +53,12 @@
   <div class="container">
     {% block content %}{% endblock %}
     <h2>Thanks</h2>
-    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="http://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
+    <p>This is derivative work from <a href="http://py3readiness.org/">py3readiness.org</a>, a site that tracks general compatibility with Python 3, which in turn is a derivative of <a href="https://pythonwheels.com/">pythonwheels.com</a>, a site that tracks which Python distributions ship the wheel distribution.</p>
     <!-- fork me -->
     <a href="https://github.com/di/pyreadiness"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://github-camo.global.ssl.fastly.net/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
     <hr>
     <footer>
-      <p>Maintained by <a href="http://github.com/di">@di</a>, source on <a href="https://github.com/di/pyreadiness">GitHub</a>.</p>
+      <p>Maintained by <a href="https://github.com/di">@di</a>, source on <a href="https://github.com/di/pyreadiness">GitHub</a>.</p>
       <p>Last updated on <span class="date">{{ updated }}</span></p>
     </footer>
   </div>


### PR DESCRIPTION
- use `https://` for links where possible
- do no longer link to `py3readiness.org`

Since the beginning of 2020 the site http://py3readiness.org/ no longer shows Python 3 Readiness. Instead, it shows ads, so we probably should not longer link to it.