### PR TITLE
Strip whitespace

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -12,9 +12,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           cache: pip
       - name: Generate
         run: |

--- a/templates/major.html
+++ b/templates/major.html
@@ -2,7 +2,7 @@
 {% block head %}
 <script type="text/javascript">
   function toggle(button) {
-    var nextState = button.dataset.state === "Show" ? "Hide" : "Show";
+    let nextState = button.dataset.state === "Show" ? "Hide" : "Show";
 
     if (button.dataset.state === "Show") {
       document.querySelectorAll(".btn-success").forEach((el) => {
@@ -18,7 +18,7 @@
     button.textContent = nextState + ' Python {{ major }} {{ "unsupported" if status.eol else "compatible"}}';
 
     document.querySelectorAll(".list").forEach((list) => {
-      var items = list.querySelectorAll(":not(.hidden)");
+      let items = list.querySelectorAll(":not(.hidden)");
 
       if (items.length) {
         items.forEach((el) => {

--- a/templates/major.html
+++ b/templates/major.html
@@ -40,13 +40,13 @@
     <h2>What is this about?</h2>
     <p>
     Python {{ major }} is <a href="https://devguide.python.org/devcycle/#end-of-life-branches">
-        {% if status.eol %}
+        {%- if status.eol -%}
             a version of Python that is past its End Of Life
-        {% elif status.dying %}
+        {%- elif status.dying -%}
             a version of Python that is nearing its End Of Life
-        {% else %}
+        {%- else -%}
             a currently supported version of Python
-        {% endif -%}
+        {%- endif -%}
     </a>. This site shows Python {{ major }} support for the {{ results|length }} most downloaded packages on <a href="https://pypi.org/">PyPI</a>:
     </p>
     <ol>


### PR DESCRIPTION
Strip that rogue space before the full stop in:

> Python 3.12 is a currently supported version of Python .

![image](https://github.com/di/pyreadiness/assets/1324225/ad173493-4589-451d-ac6f-5d501ac0c223)

https://pyreadiness.org/3.12/

Also in JavaScript: `let` (or `const`) are generally preferred over `var`.

And we should be good to use Python 3.11 for the cron, google-cloud-bigquery has supported it for a while.
