### PR TITLE
Python 3.13 RC1 is out

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ Status = collections.namedtuple(
 
 MAJORS = {
     # version: (past_eol, alpha)
-    "3.13": Status(beta=True),
+    "3.13": Status(rc=True),
     "3.12": Status(),
     "3.11": Status(),
     "3.10": Status(),


### PR DESCRIPTION
* https://discuss.python.org/t/python-3-13-0-release-candidate-1-released/59703/1
* https://www.python.org/downloads/release/python-3130rc1/