### PR TITLE
Python 3.8 is EOL

### DIFF
--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ MAJORS = {
     "3.11": Status(),
     "3.10": Status(),
     "3.9": Status(),
-    "3.8": Status(),
+    "3.8": Status(eol=True),
     "3.7": Status(eol=True),
     "3.6": Status(eol=True),
     "3.5": Status(eol=True),


### PR DESCRIPTION
One more for today!

* https://devguide.python.org/versions/
* https://github.com/python/devguide/pull/1430